### PR TITLE
Improved formatting of deseralized data

### DIFF
--- a/Deserialize php.spBundle/command.plist
+++ b/Deserialize php.spBundle/command.plist
@@ -11,7 +11,17 @@
 
 &lt;pre&gt;
 &lt;?php
- print_r( unserialize(fgets(STDIN)));
+function goFormatVarExport($string) {
+	return preg_replace(array(
+		'/=&gt;\s+array\(/im',
+		'/array\(\s+\)/im',
+	), array(
+		'=&gt; array(',
+		'array()',
+	), str_replace('array (', 'array(', $string));
+}
+
+print_r(goFormatVarExport(var_export(unserialize(fgets(STDIN)), TRUE)));
 ?&gt;
 &lt;/pre&gt;</string>
 	<key>contact</key>


### PR DESCRIPTION
Now formats the deserialized PHP according to PHP coding standards so that it can be copied into PHP code without having to adjust it in any way.

Copied this from my command in the TextMate Good Old bundle: https://github.com/goodold/goodold-tmbundle/blob/master/Commands/Unserialize.tmCommand
